### PR TITLE
Introduce color variable for body and p elements

### DIFF
--- a/0x03-sass_scss/1-color_variable.scss
+++ b/0x03-sass_scss/1-color_variable.scss
@@ -1,0 +1,9 @@
+$main-text-colour: #3D3D3D;
+
+body {
+  color: $main-text-colour;
+}
+
+p {
+  color: $main-text-colour;
+}


### PR DESCRIPTION
| Status  | Type  | Env Vars Change |
| :---: | :---: | :---: |
| Ready | Feature | No |

## Problem

- Standardize text color for body and p elements using a Sass variable.

## Solution

- Created a new SCSS file named `1-color_variable.scss`.
- Defined a variable `$main-text-colour` with the value `#3D3D3D`.
- Applied this color to the `color` property of both the `body` and `p` elements.


## Other changes <e.g. bug fixes, UI tweaks, small refactors>
- None

## Deploy Notes

_There are no new dependencies, scripts, or environment variables introduced with this PR_

**New environment variables **:

- None

**New scripts**: 

- None

**New dependencies**:

- None

**New dev dependencies**: 

- None