### PR TITLE
Introduce nested SCSS rule for `p` tag margin

### DIFF
--- a/0x03-sass_scss/2-nested_tag.scss
+++ b/0x03-sass_scss/2-nested_tag.scss
@@ -1,0 +1,8 @@
+body {
+  margin: 0px;
+  padding: 0px;
+
+  p {
+    margin: 10px;
+  }
+}


### PR DESCRIPTION
| Status  | Type  | Env Vars Change |
| :---: | :---: | :---: |
| Ready | Feature | No |

## Problem

- Set margin and padding of the `body` element to 0px
- Add a nested rule for the `p` tag, setting its margin to 10px

## Solution

- Created a new SCSS file `2-nested_tag.scss`
- Defined the `body` element's margin and padding as 0px
- Nested the `p` tag rule under `body`, setting its margin to 10px

## Other changes <e.g. bug fixes, UI tweaks, small refactors>
- None

## Deploy Notes

_There are no new dependencies, scripts, or environment variables introduced with this PR_

**New environment variables **:

- None

**New scripts**: 

- None

**New dependencies**:

- None

**New dev dependencies**: 

- None