### PR TITLE
Introduce mixin for setting margins in SCSS

### DIFF
--- a/0x03-sass_scss/3-mixin_margins.scss
+++ b/0x03-sass_scss/3-mixin_margins.scss
@@ -1,0 +1,17 @@
+// 3-mixin_margins.scss
+
+// Define a mixin that accepts a margin value
+@mixin set-margins($value) {
+  margin-left: $value;
+  margin-right: $value;
+}
+
+// Use mixin for body
+body {
+  @include set-margins(10px);
+}
+
+// Use mixin for div
+div {
+  @include set-margins(15px);
+}


### PR DESCRIPTION
| Status  | Type  | Env Vars Change |
| :---: | :---: | :---: |
| Ready | Feature | No |

## Problem

- Need a reusable way to set margins for different elements in SCSS.

## Solution

- Created a mixin `set-margins` that accepts a margin value and applies it to `margin-left` and `margin-right`.
- Used the mixin for `body` with a margin of `10px` and for `div` with a margin of `15px`.

## Other changes <e.g. bug fixes, UI tweaks, small refactors>
- None

## Deploy Notes

_There are no new dependencies, scripts, or environment variables introduced with this PR_

**New environment variables **:

- None

**New scripts**: 

- None

**New dependencies**:

- None

**New dev dependencies**: 

- None